### PR TITLE
userservice: add Flyway migrations + ddl-auto=validate (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
 # Fitness Microservice
 
-Cloud‑native, microservices‑based fitness tracking platform with **AI‑powered workout recommendations** and **OAuth2 authentication**.
+Cloud-native, microservices-based fitness tracking platform with **AI-powered workout recommendations** and a **self-hosted JWT authentication service**.
 
 ---
 
 ## 📋 Overview
 
-Fitness Microservice is a modern, scalable fitness tracking system built with **Spring Boot microservices** and a **React frontend**. It leverages **Google Gemini AI** for personalized workout recommendations and **Keycloak** for secure authentication.
+Fitness Microservice is a modern, scalable fitness tracking system built with **Spring Boot microservices** and a **React frontend**. It leverages **Google Gemini AI** for personalized workout recommendations and an in-house **JWT auth-service** (RS256, JWKS-published) for authentication — no third-party identity provider required.
 
-The system follows cloud‑native principles such as service discovery, centralized configuration, API gateway security, and event‑driven communication.
+The system follows cloud-native principles such as service discovery, centralized configuration, API gateway security, and event-driven communication.
 
 ---
 
 ## 🚀 Tech Stack
 
 ### Backend
-- **Java 21**, Spring Boot 4.0.0, Spring Cloud 2025.1.0
-- **Spring Cloud Gateway** – API Gateway
+- **Java 21**, Spring Boot 3.3, Spring Cloud 2023.0
+- **Spring Cloud Gateway** – API Gateway, validates JWTs as an OAuth2 Resource Server (JWKS)
 - **Netflix Eureka** – Service Discovery
 - **Spring Cloud Config** – Centralized Configuration
-- **Spring Security** – OAuth2 Resource Server, JWT
-- **Keycloak** – OAuth2 / OIDC Identity Provider
-- **PostgreSQL** – Relational Database (User Service)
-- **MongoDB** – NoSQL Database (Activity & AI Services)
-- **RabbitMQ** – Message Broker
-- **WebClient** – Reactive HTTP Client
-- **Google Gemini AI** – AI Recommendations
+- **Spring Security** – Custom auth (registration / login / refresh / logout) issuing RS256 JWTs
+- **Nimbus JOSE + JWT** – JWT signing, JWKS publication
+- **Flyway** – Versioned database migrations (User Service)
+- **PostgreSQL** – Relational database (User Service)
+- **MongoDB** – NoSQL database (Activity & AI Services)
+- **RabbitMQ** – Message broker
+- **WebClient** – Reactive HTTP client
+- **Google Gemini AI** – AI recommendations
 
 ### Frontend
-- **React 19** + **Vite 7.2** – Modern Build Tool
-- **Material‑UI 7.3** – UI Components
-- **Redux Toolkit 2.11** – State Management
-- **OAuth2 Authorization Code Flow with PKCE** – Secure Auth
-- **Axios** – HTTP Client
-- **React Router 7.10** – Client-side Routing
+- **React 19** + **Vite 7.2** – Modern build tool
+- **Material-UI 7.3** – UI components
+- **Custom AuthContext** – `localStorage`-backed session, single-flight refresh, Axios interceptor for `Bearer` + 401-refresh-retry
+- **Axios** – HTTP client
+- **React Router 7.10** – Client-side routing
 
 ---
 
@@ -41,38 +41,38 @@ The system follows cloud‑native principles such as service discovery, centrali
 
 ### Presentation Layer
 - React Frontend
-- OAuth2 / JWT based authentication
+- Custom email/password forms (no external IdP redirect)
 
 ### Gateway & Security Layer
-- Spring Cloud Gateway
-- Keycloak integration
+- Spring Cloud Gateway with OAuth2 Resource Server JWT validation
+- JWKS resolved from the in-house auth-service at `/.well-known/jwks.json`
 
 ### Infrastructure Layer
 - Eureka Server (Service Discovery)
 - Config Server (Centralized Config)
 
 ### Business Services
-- **User Service** – user profiles and roles
+- **User Service** – user accounts + auth endpoints (`/api/auth/register|login|refresh|logout`), JWKS publication
 - **Activity Service** – fitness activity tracking
 - **AI Service** – workout recommendations via Gemini AI
 
 ### Data & Messaging
-- **PostgreSQL** for user data persistence
+- **PostgreSQL** for user data persistence (schema managed by Flyway)
 - **MongoDB** for activity and recommendation data
-- **RabbitMQ** for asynchronous, event‑driven communication
+- **RabbitMQ** for asynchronous, event-driven communication
 
 ---
 
 ## 📦 Microservices
 
-| Service          | Port | Description                          |
-|------------------|------|--------------------------------------|
-| Config Server    | 8888 | Centralized configuration management |
-| Eureka Server    | 8761 | Service discovery and monitoring     |
-| API Gateway      | 8080 | Secure entry point and routing       |
-| User Service     | 8081 | User management and roles            |
-| Activity Service | 8082 | Fitness activity tracking            |
-| AI Service       | 8083 | AI‑powered recommendations           |
+| Service          | Port | Description                                                  |
+|------------------|------|--------------------------------------------------------------|
+| Config Server    | 8888 | Centralized configuration management                          |
+| Eureka Server    | 8761 | Service discovery and monitoring                              |
+| API Gateway      | 8080 | Secure entry point and routing (JWT validation via JWKS)      |
+| User Service     | 8081 | User management, auth endpoints, JWKS                         |
+| Activity Service | 8082 | Fitness activity tracking                                     |
+| AI Service       | 8083 | AI-powered recommendations                                    |
 
 ---
 
@@ -84,7 +84,7 @@ fitness-microservice/
 ├── configserver/      # Centralized configuration
 ├── eureka/            # Service discovery
 ├── gateway/           # API Gateway & security
-├── userservice/       # User management
+├── userservice/       # User management + auth
 ├── activityservice/   # Activity tracking
 └── aiservice/         # AI recommendations
 ```
@@ -94,14 +94,12 @@ fitness-microservice/
 ## 🛠️ Prerequisites
 
 - **Java 21+**, Maven 3.8+
-- **Node.js 18+**, npm
-- **PostgreSQL** (5432)
+- **Node.js 20+**, npm
+- **Docker / Docker Compose** – for local infrastructure
+- **PostgreSQL** (5433 in dev compose)
   - Database: `fitness_user_db`
 - **MongoDB** (27017)
-- **RabbitMQ** (5672)
-- **Keycloak** (8181)
-  - Realm: `fitness-oauth2`
-  - Client: `oauth2-pkce-client`
+- **RabbitMQ** (5672, management UI on 15672)
 - **Google Gemini API Key**
 
 ---
@@ -109,25 +107,32 @@ fitness-microservice/
 ## 🚀 Getting Started
 
 ### 1. Start infrastructure services
-- PostgreSQL
-- MongoDB
-- RabbitMQ
-- Keycloak
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+This brings up PostgreSQL, MongoDB and RabbitMQ.
 
 ### 2. Configure environment variables
-Set the following environment variables:
+
 ```bash
-GEMINI_API_KEY=your_gemini_api_key_here
+export GEMINI_API_KEY=your_gemini_api_key_here
 ```
 
 ### 3. Start backend services in order
-- Config Server
-- Eureka Server
-- API Gateway
-- User, Activity and AI Services
+
+1. Config Server
+2. Eureka Server
+3. API Gateway
+4. User, Activity and AI Services
+
+On first boot the User Service runs **Flyway migrations** automatically (`V1__init.sql` creates the `users` and `refresh_tokens` tables). Subsequent boots run `Schema "public" is up to date`.
 
 ### 4. Start frontend
+
 ```bash
+cd frontend
 npm install
 npm run dev
 ```
@@ -138,10 +143,22 @@ npm run dev
 
 ## 🔐 Security
 
-- OAuth2 Authorization Code Flow with PKCE
-- JWT‑based authentication and authorization
-- Spring Security OAuth2 Resource Server
-- Automatic user synchronization with Keycloak
+- **Custom JWT auth-service** (`userservice`) — `POST /api/auth/register|login|refresh|logout`
+- **RS256** signed access tokens (15 min TTL) + opaque refresh tokens (30 days TTL, hashed at rest, single-use rotation)
+- **JWKS** published at `/.well-known/jwks.json`; gateway validates tokens via Spring Security OAuth2 Resource Server
+- **bcrypt** password hashing
+- Refresh-token revocation on logout, re-use detection rejects rotated tokens
+
+---
+
+## 🗄️ Database Migrations
+
+The User Service uses **Flyway** for schema management:
+
+- Migrations live in `userservice/src/main/resources/db/migration/`
+- `spring.jpa.hibernate.ddl-auto=validate` — Hibernate never auto-modifies the schema in any environment
+- `flyway.baseline-on-migrate=true` makes the integration safe on pre-existing volumes
+- New schema changes ship as `V2__*.sql`, `V3__*.sql`, … (never edit `V1__init.sql` post-merge — Flyway will fail the checksum)
 
 ---
 
@@ -149,17 +166,18 @@ npm run dev
 
 - **Eureka Dashboard:** http://localhost:8761
 - **RabbitMQ Management UI:** http://localhost:15672
-- **Keycloak Admin Console:** http://localhost:8181
+- **JWKS endpoint:** http://localhost:8080/.well-known/jwks.json
 
 ---
 
 ## ✨ Features
 
-- Secure authentication with OAuth2 / OIDC
-- Fitness activity tracking (running, cycling, gym, etc.)
-- AI‑powered personalized workout recommendations
-- Event‑driven microservices architecture
+- Self-hosted JWT authentication (no third-party redirect)
+- Fitness activity tracking (running, walking, cycling)
+- AI-powered personalized workout recommendations
+- Event-driven microservices architecture
 - Centralized configuration and service discovery
+- Versioned schema migrations via Flyway
 - Modern, responsive React UI
 
 ---

--- a/configserver/src/main/resources/config/user-service-local.yml
+++ b/configserver/src/main/resources/config/user-service-local.yml
@@ -8,8 +8,13 @@ spring:
     password: postgres123
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 0
+    locations: classpath:db/migration
 
 eureka:
   client:

--- a/configserver/src/main/resources/config/user-service.yml
+++ b/configserver/src/main/resources/config/user-service.yml
@@ -8,8 +8,13 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 0
+    locations: classpath:db/migration
 
 eureka:
   client:

--- a/userservice/pom.xml
+++ b/userservice/pom.xml
@@ -67,6 +67,14 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.flywaydb</groupId>
+			<artifactId>flyway-database-postgresql</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/userservice/src/main/resources/db/migration/V1__init.sql
+++ b/userservice/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,29 @@
+-- baseline schema (post-Keycloak removal)
+
+CREATE TABLE IF NOT EXISTS users (
+    id            VARCHAR(255)                NOT NULL,
+    email         VARCHAR(255)                NOT NULL,
+    password_hash VARCHAR(255)                NOT NULL,
+    first_name    VARCHAR(255),
+    last_name     VARCHAR(255),
+    role          VARCHAR(255),
+    created_at    TIMESTAMP(6),
+    updated_at    TIMESTAMP(6),
+    CONSTRAINT users_pkey PRIMARY KEY (id),
+    CONSTRAINT uk_users_email UNIQUE (email),
+    CONSTRAINT users_role_check CHECK (role IN ('USER', 'ADMIN'))
+);
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id          VARCHAR(255)                NOT NULL,
+    user_id     VARCHAR(255)                NOT NULL,
+    token_hash  VARCHAR(128)                NOT NULL,
+    expires_at  TIMESTAMP(6) WITH TIME ZONE NOT NULL,
+    revoked     BOOLEAN                     NOT NULL,
+    replaced_by VARCHAR(255),
+    created_at  TIMESTAMP(6),
+    CONSTRAINT refresh_tokens_pkey PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_refresh_token_hash ON refresh_tokens (token_hash);
+CREATE INDEX IF NOT EXISTS idx_refresh_user ON refresh_tokens (user_id);


### PR DESCRIPTION
Closes #27. Also closes the last open item of epic #23 (README still referenced Keycloak).

## Why

`#27` originally tracked a one-time manual `docker compose down -v` on the VPS to reset the Postgres volume after PR #26 (Keycloak removal). The "Follow-ups" section of that issue called out the underlying root cause: `spring.jpa.hibernate.ddl-auto=update` cannot reconcile breaking schema changes on existing data, and any future column rename / NOT-NULL addition will hit the same wall.

This PR replaces the manual ops dance with a **Flyway-based migration pipeline** that is safe on both fresh and existing volumes — the manual step from #27 is no longer required.

## Changes

- `userservice/pom.xml` — adds `flyway-core` + `flyway-database-postgresql` (Spring Boot–managed versions).
- `userservice/src/main/resources/db/migration/V1__init.sql` — baseline schema mirroring the post-PR #26 JPA model (`users`, `refresh_tokens`, indexes). Uses `IF NOT EXISTS` so it is a no-op against legacy volumes.
- `configserver/.../user-service.yml` + `user-service-local.yml` — `spring.jpa.hibernate.ddl-auto: update → validate`; adds `spring.flyway` block with `baseline-on-migrate=true`, `baseline-version=0`, `locations=classpath:db/migration`.
- `README.md` — removes all Keycloak references, documents the custom JWT auth service, JWKS endpoint, and the new Flyway-based migration workflow (covers the README item of epic #23).

## Local e2e (3 scenarios, all green)

**1. Fresh DB** (`docker compose down -v && up -d`):
```
Migrating schema "public" to version "1 - init"
Successfully applied 1 migration to schema "public", now at version v1
Started UserserviceApplication in 3.362 seconds
```
- 6/6 smoke tests via gateway: register 201, login 200, refresh 200 + token rotated, logout 204, refresh-after-logout 401.

**2. Restart** (volume preserved, flyway_schema_history intact):
```
Successfully validated 1 migration
Schema "public" is up to date. No migration necessary.
Started UserserviceApplication in 3.253 seconds
```

**3. Legacy volume** (existing `users` + `refresh_tokens` data, NO `flyway_schema_history` — i.e. the exact state of the production VPS today):
```
Creating Schema History table "public"."flyway_schema_history" with baseline ...
Successfully baselined schema with version: 0
Migrating schema "public" to version "1 - init"
Successfully applied 1 migration to schema "public", now at version v1
Started UserserviceApplication in 3.52 seconds
```
- All pre-existing rows preserved (`users=1, refresh_tokens=3`).
- The previously registered user could still log in with their original password, and a new register call returned 201. **No data loss.**

In all three scenarios Hibernate `ddl-auto=validate` passed cleanly with no `Schema-validation` errors.

## Production impact

- **The manual `down -v` from #27 is no longer required.** Deploying this PR to `prod` will:
  1. Boot user-service against the existing volume.
  2. Flyway baselines at v0 + applies V1 (no-op on existing tables).
  3. Hibernate validate passes; service is up.
  4. Existing user accounts and refresh tokens are preserved.
- Future schema changes ship as `V2__*.sql`, `V3__*.sql`, … — never edit `V1__init.sql` after merge (Flyway will fail the checksum).

## Test plan

- [x] Local fresh-DB boot: Flyway applies V1, smoke tests green.
- [x] Local restart: Flyway no-op, smoke tests green.
- [x] Local legacy-volume simulation: baseline v0 + V1 no-op + data preserved + login still works.
- [ ] Verify CI green on this PR.
- [ ] After merge: confirm prod user-service log shows the legacy-volume sequence above.

## Follow-ups (not in scope here)

- Replicate Flyway pattern for `activityservice` if/when it gains a relational store (currently MongoDB).
- Drop the explicit `database-platform: org.hibernate.dialect.PostgreSQLDialect` (Hibernate logs `HHH90000025` warning that it's auto-detected). Pure log-noise cleanup.